### PR TITLE
Fix broken tok2.com links

### DIFF
--- a/8bit/fm7/fm-7.md
+++ b/8bit/fm7/fm-7.md
@@ -272,8 +272,8 @@ upper right; below is looking outward from the system unit.
 <!-------------------------------------------------------------------->
 [fm7assem]: https://archive.org/details/FM7MC6809ASM
 [fm7sysspec]: https://archive.org/details/FM7SystemSpecifications
-[fm7w-hw]: http://www23.tok2.com/home/fm7emu/ysm7/ysm72/ysm72.htm#TOP
-[fm7w-mmap]: http://www23.tok2.com/home/fm7emu/ysm7/ysm7d/ysm7d.htm
+[fm7w-hw]: https://web.archive.org/web/20160719040422/http://www23.tok2.com/home/fm7emu/ysm7/ysm72/ysm72.htm#TOP
+[fm7w-mmap]: https://web.archive.org/web/20160705051334/http://www23.tok2.com/home/fm7emu/ysm7/ysm7d/ysm7d.htm
 [haserin]: http://rpcg1.home.mindspring.com/difference.html
 [lgreen]: http://www.nausicaa.net/~lgreenf/fm7page.htm
 [shuwa83]: https://archive.org/stream/fbasicii#page/n4/mode/1up


### PR DESCRIPTION
Links look like they have broken; updated using an archive.org link for the `fm7-hw` and `-mmap` sections.