### PR TITLE
8bit/sony/smc777: Information on SMC-777/C option cards

### DIFF
--- a/8bit/sony/smc777.md
+++ b/8bit/sony/smc777.md
@@ -1,0 +1,17 @@
+# Sony SMC-777/SMC-777C
+
+## Models
+### SMC-777
+
+### SMC-777C
+Identical to the SMC-777 in most ways. Comes with more software, as well as 16-of-4096-colour graphics. Only available in black.
+
+## Option Boards
+
+### SMI-752: Kanji ROM card
+
+### SMI-733: Colour palette board
+Upgrades the SMC-777 to the SMC-777C specification. Changes from 16 fixed colour palette, allowing software to choose 16 colours of 4096 available colours.
+
+## Primary Sources
+ * [ratscats](https://ratscats.client.jp/so-smc777.html) scanned copy of sales catalogue, including peripherals, available monitors, and prices


### PR DESCRIPTION
Gathered information from ratscats website to figure out what the part number of the 4096-colour palette card was, decided to add it here as it took me a bit of research to find.