### PR TITLE
8/nec/6001: floppy drive details, EROM

### DIFF
--- a/8bit/nec/6001.md
+++ b/8bit/nec/6001.md
@@ -16,9 +16,17 @@ Models and Accessories
 ----------------------
 
 - __PC-6011__ expansion unit. Plus into cartridge slot on the side; adds
-  three cartridge slots and 36 (?) pin mini-ribbon connector for floppy kit.
+  three cartridge slots and 36-pin Centronics/57-series mini-ribbon connector for floppy kit.
   (Probably parallel interface à la PC-8001.)
 
+Floppy Disk
+-----------
+NEC "intelligent type" floppy disk drives (e.g. PC-8031, PC-80S31) can be
+connected through the aforementioned PC-6011 interface to original models,
+but use of the drive requires Extended BASIC cartridge to be booted.
+
+The PC-6001 appears unable to boot from floppy disks, even those with the
+`SYS` header and when using an Extended BASIC cartridge[p6_tech fdd].
 
 Memory Map
 ----------
@@ -115,9 +123,8 @@ trigger the slot switch, making the `MSW1/2` short unnecessary.
 
 `/RAS2`, `/DRD2`, `/WE` and `/EXCAS` are RAM-related signals.
 
-`/EROM`  is somehow related to the internal ROM; perhaps a board asserting
-can disable the internal ROM?
-
+`/EROM`  is somehow related to the internal ROM; it is stated that it is
+"for disabling internal BASIC ROM."
 
 RAM and ROM Expansion
 ---------------------
@@ -157,7 +164,6 @@ down for digital (RGBI) and up for analog (RGB).
 [PC-6001 SCREEN MODE4 の色滲みを調べる][vid4] discusses (in huge detail,
 including an intro to NTSC color) games that use NTSC color artificts.
 
-
 References
 ----------
 
@@ -181,8 +187,8 @@ References
   PC-6001 stuff.
 - \[MPC-P60] [ユニバーサル基板 ＭＰＣ－Ｐ６０ 添付資料]. Documents a
   cartridge protoboard and PC-6001 and MSX interfacing.
-
-
+- \[p6tech fdd] PC-6001シリーズ技術情報いろいろ. _PC-6001 series various technical information_.
+  Hand-gathered accumulation of various PC-6001/mkII/6601 knowledge.
 
 <!-------------------------------------------------------------------->
 [BELUGA]: http://tulip-house.ddo.jp/digital/BELUGA/
@@ -193,5 +199,6 @@ References
 [p6ers ROM]: http://p6ers.net/mm/pc-6001/dev/flashromcard/8k.html
 [p6ers basmem]: http://p6ers.net/hashi/furoku2.html
 [p6ram]: http://sbeach.seesaa.net/article/387861385.html
+[p6tech fdd]: http://000.la.coocan.jp/p6/tech.html#auto_fd
 [tsutsui]: https://ch.nicovideo.jp/tsutsui/blomaga/ar1315944
 [vid4]: http://p6ers.net/mm/pc-6001/dev/screen4color/


### PR DESCRIPTION
 - Clarified /EROM as it was mentioned on linked 8K ROM page
 - Added reference to p6tech's statement that PC-6001 original model cannot autoboot on floppy